### PR TITLE
Add `AsServiceHandler`

### DIFF
--- a/knit.go
+++ b/knit.go
@@ -84,16 +84,8 @@ type Gateway struct {
 // an [*http.ServeMux]'s Handle method:
 //
 //	mux.Handle(gateway.AsHandler())
-func (g *Gateway) AsHandler() (path string, h http.Handler) {
-	return gatewayv1alpha1connect.NewKnitServiceHandler(&handler{gateway: g})
-}
-
-// AsServiceHandler returns a [gatewayv1alpha1connect.KnitServiceHandle] for g. This can be used
-// to register the gateway similar to other Connect services:
-//
-//	mux.Handle(gatewayv1alpha1connect.NewKnitServiceHandler(gateway.AsServiceHandler(), handlerOptions...))
-func (g *Gateway) AsServiceHandler() gatewayv1alpha1connect.KnitServiceHandler {
-	return &handler{gateway: g}
+func (g *Gateway) AsHandler(handlerOptions ...connect.HandlerOption) (path string, h http.Handler) {
+	return gatewayv1alpha1connect.NewKnitServiceHandler(&handler{gateway: g}, handlerOptions...)
 }
 
 // AddService adds the given service's methods as available outbound RPCs.

--- a/knit.go
+++ b/knit.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"buf.build/gen/go/bufbuild/knit/bufbuild/connect-go/buf/knit/gateway/v1alpha1/gatewayv1alpha1connect"
-	"buf.build/gen/go/bufbuild/knit/protocolbuffers/go/buf/knit/v1alpha1"
+	knitv1alpha1 "buf.build/gen/go/bufbuild/knit/protocolbuffers/go/buf/knit/v1alpha1"
 	"github.com/bufbuild/connect-go"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -86,6 +86,14 @@ type Gateway struct {
 //	mux.Handle(gateway.AsHandler())
 func (g *Gateway) AsHandler() (path string, h http.Handler) {
 	return gatewayv1alpha1connect.NewKnitServiceHandler(&handler{gateway: g})
+}
+
+// AsServiceHandler returns a [KnitServiceHandler] for g. This can be used
+// to register the gateway similar to other Connect services:
+//
+//	mux.Handle(gatewayv1alpha1connect.NewKnitServiceHandler(gateway.AsServiceHandler(), handlerOptions...))
+func (g *Gateway) AsServiceHandler() gatewayv1alpha1connect.KnitServiceHandler {
+	return &handler{gateway: g}
 }
 
 // AddService adds the given service's methods as available outbound RPCs.

--- a/knit.go
+++ b/knit.go
@@ -88,7 +88,7 @@ func (g *Gateway) AsHandler() (path string, h http.Handler) {
 	return gatewayv1alpha1connect.NewKnitServiceHandler(&handler{gateway: g})
 }
 
-// AsServiceHandler returns a [KnitServiceHandler] for g. This can be used
+// AsServiceHandler returns a [gatewayv1alpha1connect.KnitServiceHandle] for g. This can be used
 // to register the gateway similar to other Connect services:
 //
 //	mux.Handle(gatewayv1alpha1connect.NewKnitServiceHandler(gateway.AsServiceHandler(), handlerOptions...))


### PR DESCRIPTION
Add `AsServiceHandler` method to the `Gateway` to return it as a `KnitServiceHandler`. The existing `AsHandler` returns an `http.Handler` which doesn't let users pass custom handler options like interceptors.