### PR TITLE
Return `invalid_args` if params JSON is invalid

### DIFF
--- a/format.go
+++ b/format.go
@@ -129,7 +129,10 @@ func parseMessage(value *structpb.Value, msg proto.Message, res TypeResolver) er
 	if err != nil {
 		return err
 	}
-	return protojson.UnmarshalOptions{Resolver: res}.Unmarshal(data, msg)
+	if err := (protojson.UnmarshalOptions{Resolver: res}).Unmarshal(data, msg); err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	return nil
 }
 
 //nolint:gocyclo

--- a/stitcher.go
+++ b/stitcher.go
@@ -94,6 +94,10 @@ func (s *stitcher) stitch(ctx context.Context, patches [][]*patch, fallbackCatch
 				params[key] = msg.Interface()
 				continue
 			}
+			// TODO: We should move the calls to parseMessage to the start of handling, when validating the query.
+			// Currently, we could end up doing some work (top-level method names) even though the request is bad
+			// and doomed to fail. Also, its currently possible that we might re-parse this message even though
+			// we only need to do so once.
 			if err := parseMessage(key.params, msg.Interface(), s.gateway.TypeResolver); err != nil {
 				return fmt.Errorf("could not unmarshal request type %q for relation %q of type %q: %w",
 					msg.Descriptor().FullName(), patchGroup[0].mask.Name, patchGroup[0].target.ProtoReflect().Descriptor().FullName(), err,


### PR DESCRIPTION
The code currently is not assigning a Connect code, so it is resulting in an internal error. Oops.

Fixes TCN-1732