### PR TITLE
Add support for TLS to standalone knitgateway

### DIFF
--- a/cmd/knitgateway/main.go
+++ b/cmd/knitgateway/main.go
@@ -107,7 +107,7 @@ func main() {
 		TLSConfig:         config.TLSConfig,
 	}
 
-	ignored := make(chan os.Signal)
+	ignored := make(chan os.Signal, 1)
 	signal.Notify(ignored, syscall.SIGHUP)
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT, syscall.SIGALRM, syscall.SIGQUIT, syscall.SIGTSTP, syscall.SIGUSR1, syscall.SIGUSR2)

--- a/codec.go
+++ b/codec.go
@@ -30,11 +30,11 @@ func (d *dynamicCodec) Name() string {
 	return d.codec.Name()
 }
 
-func (d *dynamicCodec) Marshal(a any) ([]byte, error) {
-	if im, ok := a.(*indirectMessage); ok {
-		a = im.a
+func (d *dynamicCodec) Marshal(msg any) ([]byte, error) {
+	if im, ok := msg.(*indirectMessage); ok {
+		msg = im.a
 	}
-	return d.codec.Marshal(a)
+	return d.codec.Marshal(msg)
 }
 
 func (d *dynamicCodec) Unmarshal(bytes []byte, msg any) error {
@@ -59,7 +59,7 @@ type deferredMessage struct {
 	codec connect.Codec
 }
 
-func (dm *deferredMessage) unmarshal(a any) error {
+func (dm *deferredMessage) unmarshal(msg any) error {
 	if dm.codec == nil {
 		// This can happen when the message size is zero: the Connect
 		// framework doesn't bother calling codec.Unmarshal, so this
@@ -71,7 +71,7 @@ func (dm *deferredMessage) unmarshal(a any) error {
 		}
 		return fmt.Errorf("internal: %d bytes, but codec to unmarshal is nil", len(dm.bytes))
 	}
-	return dm.codec.Unmarshal(dm.bytes, a)
+	return dm.codec.Unmarshal(dm.bytes, msg)
 }
 
 type defaultProtoCodec struct{}

--- a/codec.go
+++ b/codec.go
@@ -60,6 +60,17 @@ type deferredMessage struct {
 }
 
 func (dm *deferredMessage) unmarshal(a any) error {
+	if dm.codec == nil {
+		// This can happen when the message size is zero: the Connect
+		// framework doesn't bother calling codec.Unmarshal, so this
+		// deferred message never sees the codec.
+		// We'll just double-check that the size is zero and, if so,
+		// don't need to do anything.
+		if len(dm.bytes) == 0 {
+			return nil
+		}
+		return fmt.Errorf("internal: %d bytes, but codec to unmarshal is nil", len(dm.bytes))
+	}
 	return dm.codec.Unmarshal(dm.bytes, a)
 }
 

--- a/internal/app/knitgateway/config.go
+++ b/internal/app/knitgateway/config.go
@@ -107,11 +107,11 @@ func LoadConfig(ctx context.Context, path string) (*GatewayConfig, error) { //no
 		return nil, fmt.Errorf("listen.tls: invalid configuration: %w", err)
 	}
 	// we use this to validate the default_tls config (and can discard the result)
-	_, err = configureClientTLS(extConf.DefaultTLS)
+	_, err = configureClientTLS(extConf.DefaultBackendTLS)
 	if err != nil {
 		return nil, fmt.Errorf("default_tls: invalid configuration: %w", err)
 	}
-	if extConf.DefaultTLS != nil && extConf.DefaultTLS.ServerName != "" {
+	if extConf.DefaultBackendTLS != nil && extConf.DefaultBackendTLS.ServerName != "" {
 		return nil, fmt.Errorf("default_tls: invalid configuration: server_name property cannot be used in default settings, only in per-backend config")
 	}
 
@@ -166,7 +166,7 @@ func LoadConfig(ctx context.Context, path string) (*GatewayConfig, error) { //no
 				return nil, fmt.Errorf("backend config #%d: tls stanza present but URL scheme is not https", i+1)
 			}
 		} else {
-			clientTLS, err = configureClientTLS(mergeClientTLSConfig(backendConf.TLS, extConf.DefaultTLS))
+			clientTLS, err = configureClientTLS(mergeClientTLSConfig(backendConf.TLS, extConf.DefaultBackendTLS))
 			if err != nil {
 				return nil, fmt.Errorf("backend config #%d: tls: invalid configuration: %w", i+1, err)
 			}
@@ -218,9 +218,9 @@ func LoadConfig(ctx context.Context, path string) (*GatewayConfig, error) { //no
 }
 
 type externalGatewayConfig struct {
-	Listen     externalListenConfig     `yaml:"listen"`
-	Backends   []externalBackendConfig  `yaml:"backends"`
-	DefaultTLS *externalClientTLSConfig `yaml:"default_tls"`
+	Listen            externalListenConfig     `yaml:"listen"`
+	Backends          []externalBackendConfig  `yaml:"backends"`
+	DefaultBackendTLS *externalClientTLSConfig `yaml:"backend_tls"`
 }
 
 type externalListenConfig struct {

--- a/internal/app/knitgateway/config.go
+++ b/internal/app/knitgateway/config.go
@@ -72,7 +72,7 @@ type ServiceConfig struct {
 
 // LoadConfig reads the config file at the given path and returns the resulting
 // GatewayConfig on success.
-func LoadConfig(ctx context.Context, path string) (*GatewayConfig, error) {
+func LoadConfig(ctx context.Context, path string) (*GatewayConfig, error) { //nolint:gocyclo
 	configInput, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/internal/app/knitgateway/descriptors.go
+++ b/internal/app/knitgateway/descriptors.go
@@ -64,8 +64,23 @@ func (f *fileDescriptorSetSource) FindExtensionByNumber(message protoreflect.Ful
 	return f.types.FindExtensionByNumber(message, field)
 }
 
-// The following code was copied from buf curl's implementation.
-// See github.com/bufbuild/buf/private/buf/bufcurl.NewServerReflectionResolver
+type deferredGRPCDescriptorSource struct {
+	ctx     context.Context //nolint:containedctx
+	opts    []connect.ClientOption
+	baseURL string
+}
+
+func (d *deferredGRPCDescriptorSource) FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error) {
+	return nil, fmt.Errorf("internal: unable to use gRPC reflection because HTTP client not yet initialized")
+}
+
+func (d *deferredGRPCDescriptorSource) FindExtensionByNumber(protoreflect.FullName, protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	return nil, fmt.Errorf("internal: unable to use gRPC reflection because HTTP client not yet initialized")
+}
+
+func (d *deferredGRPCDescriptorSource) WithHTTPClient(client connect.HTTPClient) DescriptorSource {
+	return newGRPCDescriptorSource(d.ctx, client, d.opts, d.baseURL)
+}
 
 type grpcDescriptorSource struct {
 	ctx    context.Context //nolint:containedctx

--- a/internal/app/knitgateway/gateway.go
+++ b/internal/app/knitgateway/gateway.go
@@ -61,7 +61,7 @@ func CreateGateway(config *GatewayConfig) (*knit.Gateway, error) {
 		}
 		descSource := svcConf.Descriptors
 		if deferredSrc, ok := descSource.(*deferredGRPCDescriptorSource); ok {
-			descSource = deferredSrc.WithHTTPClient(httpClient)
+			deferredSrc.WithHTTPClient(httpClient)
 		}
 
 		desc, err := descSource.FindDescriptorByName(protoreflect.FullName(svcName))

--- a/internal/app/knitgateway/gateway.go
+++ b/internal/app/knitgateway/gateway.go
@@ -32,10 +32,11 @@ const (
 	clientIdentityHeader = "Knit-Client-Subject"
 )
 
+//nolint:gochecknoglobals
 var (
 	// defaultH2CClient is like http.DefaultClient except that it will use HTTP/2 over plaintext
 	// (aka "H2C") to send requests to servers.
-	defaultH2CClient = &http.Client{ //nolint:gochecknoglobals
+	defaultH2CClient = &http.Client{
 		Transport: &http2.Transport{
 			AllowHTTP: true,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
@@ -71,7 +72,7 @@ func CreateGateway(config *GatewayConfig) (*knit.Gateway, error) {
 		if !ok {
 			return nil, fmt.Errorf("%s is a %s, not a service", svcName, descriptorKind(desc))
 		}
-		opts := append(svcConf.ConnectOpts, connect.WithInterceptors(&certForwardingInterceptor{}))
+		opts := append(svcConf.ConnectOpts, connect.WithInterceptors(&certForwardingInterceptor{})) //nolint:gocritic
 		err = gateway.AddService(
 			svc,
 			knit.WithRoute(svcConf.BaseURL),
@@ -126,7 +127,7 @@ func makeHTTPClient(config ServiceConfig) (connect.HTTPClient, error) {
 		if err := checkUnixSocket(config.UnixSocket); err != nil {
 			return nil, errorHasFilename(err, config.UnixSocket)
 		}
-		dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dial = func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return defaultDialer.DialContext(ctx, "unix", config.UnixSocket)
 		}
 	}

--- a/internal/app/knitgateway/gateway.go
+++ b/internal/app/knitgateway/gateway.go
@@ -20,28 +20,46 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
+	"github.com/bufbuild/connect-go"
 	"github.com/bufbuild/knit-go"
 	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// DefaultH2CClient is like http.DefaultClient except that it will use HTTP/2 over plaintext
-// (aka "H2C") to send requests to servers.
-var DefaultH2CClient = &http.Client{ //nolint:gochecknoglobals
-	Transport: &http2.Transport{
-		AllowHTTP: true,
-		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, network, addr)
+var (
+	// defaultH2CClient is like http.DefaultClient except that it will use HTTP/2 over plaintext
+	// (aka "H2C") to send requests to servers.
+	defaultH2CClient = &http.Client{ //nolint:gochecknoglobals
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			},
 		},
-	},
-}
+	}
+
+	defaultDialer = &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+)
 
 // CreateGateway creates a Knit gateway with the given configuration.
 func CreateGateway(config *GatewayConfig) (*knit.Gateway, error) {
 	gateway := &knit.Gateway{}
 	for svcName, svcConf := range config.Services {
-		desc, err := svcConf.Descriptors.FindDescriptorByName(protoreflect.FullName(svcName))
+		httpClient, err := makeHTTPClient(svcConf)
+		if err != nil {
+			return nil, fmt.Errorf("backend #%d: failed to create HTTP client: %w", svcConf.Index+1, err)
+		}
+		descSource := svcConf.Descriptors
+		if deferredSrc, ok := descSource.(*deferredGRPCDescriptorSource); ok {
+			descSource = deferredSrc.WithHTTPClient(httpClient)
+		}
+
+		desc, err := descSource.FindDescriptorByName(protoreflect.FullName(svcName))
 		if err != nil {
 			return nil, fmt.Errorf("could not get descriptor for service %s: %w", svcName, err)
 		}
@@ -49,20 +67,73 @@ func CreateGateway(config *GatewayConfig) (*knit.Gateway, error) {
 		if !ok {
 			return nil, fmt.Errorf("%s is a %s, not a service", svcName, descriptorKind(desc))
 		}
-		httpClient := http.DefaultClient
-		if svcConf.H2C {
-			httpClient = DefaultH2CClient
-		}
 		err = gateway.AddService(
 			svc,
 			knit.WithRoute(svcConf.BaseURL),
 			knit.WithClient(httpClient),
 			knit.WithClientOptions(svcConf.ConnectOpts...),
-			knit.WithTypeResolver(typeResolver{DescriptorSource: svcConf.Descriptors}),
+			knit.WithTypeResolver(typeResolver{DescriptorSource: descSource}),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to register service %s with gateway: %w", svcName, err)
 		}
 	}
 	return gateway, nil
+}
+
+func makeHTTPClient(config ServiceConfig) (connect.HTTPClient, error) {
+	if config.TLSConfig == nil && config.UnixSocket == "" {
+		// can use default clients
+		if config.H2C {
+			return defaultH2CClient, nil
+		}
+		return http.DefaultClient, nil
+	}
+
+	dial := defaultDialer.DialContext
+	if config.UnixSocket != "" {
+		if err := checkUnixSocket(config.UnixSocket); err != nil {
+			return nil, errorHasFilename(err, config.UnixSocket)
+		}
+		dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return defaultDialer.DialContext(ctx, "unix", config.UnixSocket)
+		}
+	}
+
+	if config.H2C {
+		// This is the same as used above in defaultH2CClient
+		transport := &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return dial(ctx, network, addr)
+			},
+		}
+		if config.TLSConfig != nil {
+			transport.TLSClientConfig = config.TLSConfig
+		}
+		return &http.Client{Transport: transport}, nil
+	}
+
+	// This is the same as http.DefaultTransport.
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dial,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if config.TLSConfig != nil {
+		transport.TLSClientConfig = config.TLSConfig
+	}
+	return &http.Client{Transport: transport}, nil
+}
+
+func checkUnixSocket(socketPath string) error {
+	conn, err := defaultDialer.Dial("unix", socketPath)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
 }

--- a/internal/app/knitgateway/gateway.go
+++ b/internal/app/knitgateway/gateway.go
@@ -34,20 +34,20 @@ const (
 
 //nolint:gochecknoglobals
 var (
+	defaultDialer = &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
 	// defaultH2CClient is like http.DefaultClient except that it will use HTTP/2 over plaintext
 	// (aka "H2C") to send requests to servers.
 	defaultH2CClient = &http.Client{
 		Transport: &http2.Transport{
 			AllowHTTP: true,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-				return (&net.Dialer{}).DialContext(ctx, network, addr)
+				return defaultDialer.DialContext(ctx, network, addr)
 			},
 		},
-	}
-
-	defaultDialer = &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
 	}
 )
 

--- a/internal/app/knitgateway/tls.go
+++ b/internal/app/knitgateway/tls.go
@@ -136,6 +136,12 @@ func configureServerTLS(conf *externalServerTLSConfig) (*tls.Config, error) {
 
 func configureClientTLS(conf *externalClientTLSConfig) (*tls.Config, error) {
 	var tlsConf tls.Config
+	if conf == nil {
+		tlsConf.MinVersion = defaultClientMinTLSVersion
+		tlsConf.CipherSuites = defaultCipherSuites
+		return &tlsConf, nil
+	}
+
 	if (conf.Cert == nil) != (conf.Key == nil) {
 		return nil, fmt.Errorf("if either 'cert' and 'key' is specified then both must be specified")
 	}
@@ -209,6 +215,7 @@ func mergeClientTLSConfig(conf, defaults *externalClientTLSConfig) *externalClie
 	if merged.Key == nil {
 		merged.Key = defaults.Key
 	}
+	// ServerName property intentionally skipped since defaults should not include it
 
 	return &merged
 }

--- a/internal/app/knitgateway/tls.go
+++ b/internal/app/knitgateway/tls.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package knitgateway
 
 import (
@@ -19,6 +33,7 @@ const (
 	defaultClientMinTLSVersion = tls.VersionTLS12
 )
 
+//nolint:gochecknoglobals
 var (
 	defaultCipherSuites = []uint16{
 		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
@@ -82,7 +97,7 @@ type clientCertContextKey struct{}
 func configureServerTLS(conf *externalServerTLSConfig) (*tls.Config, error) {
 	if conf == nil {
 		// not using TLS if no 'listen.tls' stanza provided
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 	var tlsConf tls.Config
 	if conf.Cert == "" || conf.Key == "" {
@@ -176,7 +191,7 @@ func configureClientTLS(conf *externalClientTLSConfig) (*tls.Config, error) {
 	}
 
 	if conf.SkipVerify != nil && *conf.SkipVerify {
-		tlsConf.InsecureSkipVerify = true
+		tlsConf.InsecureSkipVerify = true //nolint:gosec
 	} else if conf.CACert != nil {
 		var err error
 		tlsConf.RootCAs, err = loadCertificatePool(*conf.CACert)
@@ -220,8 +235,8 @@ func mergeClientTLSConfig(conf, defaults *externalClientTLSConfig) *externalClie
 	return &merged
 }
 
-func parseTLSVersion(v string) (uint16, error) {
-	switch v {
+func parseTLSVersion(version string) (uint16, error) {
+	switch version {
 	case tlsVersion10:
 		return tls.VersionTLS10, nil
 	case tlsVersion11:
@@ -232,7 +247,7 @@ func parseTLSVersion(v string) (uint16, error) {
 		return tls.VersionTLS13, nil
 	default:
 		return 0, fmt.Errorf("%q is not a valid TLS version; instead use %q, %q, %q, or %q",
-			v, tlsVersion10, tlsVersion11, tlsVersion12, tlsVersion13)
+			version, tlsVersion10, tlsVersion11, tlsVersion12, tlsVersion13)
 	}
 }
 

--- a/internal/app/knitgateway/tls.go
+++ b/internal/app/knitgateway/tls.go
@@ -1,6 +1,7 @@
 package knitgateway
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -63,6 +64,20 @@ var (
 		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 	}
 )
+
+// ContextWithClientCert stores the given client certificate in the given context. This is set
+// when handling an incoming request, allowing the client's identity to be sent to backends
+// in request headers.
+func ContextWithClientCert(ctx context.Context, clientCert *x509.Certificate) context.Context {
+	return context.WithValue(ctx, clientCertContextKey{}, clientCert)
+}
+
+func clientCertFromContext(ctx context.Context) *x509.Certificate {
+	cert, _ := ctx.Value(clientCertContextKey{}).(*x509.Certificate)
+	return cert
+}
+
+type clientCertContextKey struct{}
 
 func configureServerTLS(conf *externalServerTLSConfig) (*tls.Config, error) {
 	if conf == nil {

--- a/internal/app/knitgateway/tls.go
+++ b/internal/app/knitgateway/tls.go
@@ -1,0 +1,305 @@
+package knitgateway
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// These constants and vars are the defaults for crypto/tls package.
+// But we set them explicitly just in case the defaults ever change.
+// We don't want defaults changing without realizing it.
+
+const (
+	defaultServerMinTLSVersion = tls.VersionTLS10
+	defaultClientMinTLSVersion = tls.VersionTLS12
+)
+
+var (
+	defaultCipherSuites = []uint16{
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	}
+
+	allCipherSuites = map[string]uint16{
+		// enabled by default:
+		"TLS_RSA_WITH_AES_128_CBC_SHA":                  tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_RSA_WITH_AES_256_CBC_SHA":                  tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_GCM_SHA256":               tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_RSA_WITH_AES_256_GCM_SHA384":               tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		// disabled by default:
+		"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	}
+)
+
+func configureServerTLS(conf *externalServerTLSConfig) (*tls.Config, error) {
+	if conf == nil {
+		// not using TLS if no 'listen.tls' stanza provided
+		return nil, nil
+	}
+	var tlsConf tls.Config
+	if conf.Cert == "" || conf.Key == "" {
+		return nil, fmt.Errorf("both 'cert' and 'key' properties must be specified")
+	}
+	certs, err := loadCertificateAndKey(conf.Cert, conf.Key)
+	if err != nil {
+		return nil, err
+	}
+	tlsConf.Certificates = certs
+
+	if conf.MinVersion == "" {
+		tlsConf.MinVersion = defaultServerMinTLSVersion
+	} else {
+		var err error
+		tlsConf.MinVersion, err = parseTLSVersion(conf.MinVersion)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if conf.Ciphers == nil {
+		// This is the default for crypto/tls. But we set it explicitly just
+		// in case the default ever changes. We don't want our defaults
+		// changing without realizing it.
+		tlsConf.CipherSuites = defaultCipherSuites
+	} else {
+		var err error
+		tlsConf.CipherSuites, err = parseCipherSuites(conf.Ciphers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if conf.ClientCerts != nil {
+		if conf.ClientCerts.Require {
+			tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
+		} else {
+			tlsConf.ClientAuth = tls.VerifyClientCertIfGiven
+		}
+		if conf.ClientCerts.CACert == "" {
+			return nil, fmt.Errorf("'client_certs' config is enabled but 'ca_cert' property is missing")
+		}
+		var err error
+		tlsConf.ClientCAs, err = loadCertificatePool(conf.ClientCerts.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("'client_certs.cacert' config: %w", err)
+		}
+	}
+
+	return &tlsConf, nil
+}
+
+func configureClientTLS(conf *externalClientTLSConfig) (*tls.Config, error) {
+	var tlsConf tls.Config
+	if (conf.Cert == nil) != (conf.Key == nil) {
+		return nil, fmt.Errorf("if either 'cert' and 'key' is specified then both must be specified")
+	}
+	if conf.Cert != nil {
+		certs, err := loadCertificateAndKey(*conf.Cert, *conf.Key)
+		if err != nil {
+			return nil, err
+		}
+		tlsConf.Certificates = certs
+	}
+
+	if conf.MinVersion == nil {
+		tlsConf.MinVersion = defaultClientMinTLSVersion
+	} else {
+		var err error
+		tlsConf.MinVersion, err = parseTLSVersion(*conf.MinVersion)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if conf.Ciphers == nil {
+		// This is the default for crypto/tls. But we set it explicitly just
+		// in case the default ever changes. We don't want our defaults
+		// changing without realizing it.
+		tlsConf.CipherSuites = defaultCipherSuites
+	} else {
+		var err error
+		tlsConf.CipherSuites, err = parseCipherSuites(conf.Ciphers)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if conf.SkipVerify != nil && *conf.SkipVerify {
+		tlsConf.InsecureSkipVerify = true
+	} else if conf.CACert != nil {
+		var err error
+		tlsConf.RootCAs, err = loadCertificatePool(*conf.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("'cacert' config: %w", err)
+		}
+	}
+
+	return &tlsConf, nil
+}
+
+func mergeClientTLSConfig(conf, defaults *externalClientTLSConfig) *externalClientTLSConfig {
+	if conf == nil {
+		return defaults
+	}
+	if defaults == nil {
+		return conf
+	}
+
+	merged := *conf
+	if merged.MinVersion == nil {
+		merged.MinVersion = defaults.MinVersion
+	}
+	if merged.Ciphers == nil {
+		merged.Ciphers = defaults.Ciphers
+	}
+	if merged.CACert == nil {
+		merged.CACert = defaults.CACert
+	}
+	if merged.SkipVerify == nil {
+		merged.SkipVerify = defaults.SkipVerify
+	}
+	if merged.Cert == nil {
+		merged.Cert = defaults.Cert
+	}
+	if merged.Key == nil {
+		merged.Key = defaults.Key
+	}
+
+	return &merged
+}
+
+func parseTLSVersion(v string) (uint16, error) {
+	switch v {
+	case tlsVersion10:
+		return tls.VersionTLS10, nil
+	case tlsVersion11:
+		return tls.VersionTLS11, nil
+	case tlsVersion12:
+		return tls.VersionTLS12, nil
+	case tlsVersion13:
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("%q is not a valid TLS version; instead use %q, %q, %q, or %q",
+			v, tlsVersion10, tlsVersion11, tlsVersion12, tlsVersion13)
+	}
+}
+
+func parseCipherSuites(conf *externalCiphersConfig) ([]uint16, error) {
+	switch {
+	case conf.Allow != nil && conf.Disallow != nil:
+		return nil, fmt.Errorf("ciphers config must specify either allow or disallow, but not both")
+	case conf.Allow != nil:
+		ciphers := make([]uint16, len(conf.Allow))
+		for i, cipher := range conf.Allow {
+			cipherID, ok := allCipherSuites[cipher]
+			if !ok {
+				return nil, fmt.Errorf("allowed cipher %q is not a valid cipher suite name", cipher)
+			}
+			ciphers[i] = cipherID
+		}
+		return ciphers, nil
+	case conf.Disallow != nil:
+		// Start with the set of all cipher suites
+		cipherSet := make(map[uint16]struct{}, len(allCipherSuites))
+		for _, v := range allCipherSuites {
+			cipherSet[v] = struct{}{}
+		}
+		// remove the ones that are disallowed
+		for _, cipher := range conf.Disallow {
+			cipherID, ok := allCipherSuites[cipher]
+			if !ok {
+				return nil, fmt.Errorf("disallowed cipher %q is not a valid cipher suite name", cipher)
+			}
+			delete(cipherSet, cipherID)
+		}
+		// return the remaining ones as a slice
+		ciphers := make([]uint16, 0, len(cipherSet))
+		for id := range cipherSet {
+			ciphers = append(ciphers, id)
+		}
+		sort.Slice(ciphers, func(i, j int) bool {
+			return ciphers[i] < ciphers[j]
+		})
+		return ciphers, nil
+	default:
+		return nil, fmt.Errorf("ciphers config must specify either allow or disallow; neither was present")
+	}
+}
+
+func loadCertificateAndKey(cert, key string) ([]tls.Certificate, error) {
+	if cert == "" {
+		return nil, fmt.Errorf("cert filename is empty")
+	}
+	if key == "" {
+		return nil, fmt.Errorf("key filename is empty")
+	}
+	certData, err := os.ReadFile(cert)
+	if err != nil {
+		return nil, errorHasFilename(err, cert)
+	}
+	keyData, err := os.ReadFile(key)
+	if err != nil {
+		return nil, errorHasFilename(err, key)
+	}
+	certPair, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		return nil, err
+	}
+	certPair.Leaf, err = x509.ParseCertificate(certPair.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+	return []tls.Certificate{certPair}, nil
+}
+
+func loadCertificatePool(cacert string) (*x509.CertPool, error) {
+	if cacert == "" {
+		return nil, fmt.Errorf("filename is empty")
+	}
+	data, err := os.ReadFile(cacert)
+	if err != nil {
+		return nil, errorHasFilename(err, cacert)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf("no certificates could be successfully parsed from file %s", cacert)
+	}
+	return pool, nil
+}
+
+func errorHasFilename(err error, filename string) error {
+	if strings.Contains(err.Error(), filename) {
+		return err
+	}
+	return fmt.Errorf("%s: %w", filename, err)
+}

--- a/knitgateway.example.yaml
+++ b/knitgateway.example.yaml
@@ -220,10 +220,10 @@ backends:
 # If many or all backends use the same TLS configuration, then
 # specify it here instead of repeating it in the 'tls' stanza for
 # each backend.
-#default_tls:
+#backend_tls:
   # This section supports all of the same properties as the 'tls'
   # section under 'backends' above, EXCEPT for 'server_name'. That
-  # property must be provided on a per-backend basis.
+  # property, if used, must be provided on a per-backend basis.
   #min_version: 1.2
   #ciphers:
     #allow: []

--- a/knitgateway.example.yaml
+++ b/knitgateway.example.yaml
@@ -16,16 +16,89 @@
 # http://localhost:30480.
 
 listen:
-  # By default, the server will only bind to the loop back interface.
-  # You can set this to 0.0.0.0 to accept requests on all network
-  # interfaces.
-  #bind_address: 127.0.0.1
+  # By default, the server binds to all interfaces. You can set
+  # this to 127.0.0.1 to accept requests only on the loopback
+  # interface.
+  #bind_address: 0.0.0.0
 
-  # By default, the server will use an ephemeral port (configured
-  # as port zero). It will print the actual ephemeral port at
-  # startup. You can set this property to instead use a stable
-  # port that can be statically configured in clients.
+  # A port is required in order to listen on TCP socket. If not
+  # specified then a unix_socket must be specified.
   port: 30480
+
+  # If specified, the server will listen on a unix domain socket.
+  # This is in addition to listening on TCP socket if port is also
+  # specified.
+  #unix_socket: /path/to/domain/socket
+
+  # If the "tls" section is present, clients must use TLS (aka SSL)
+  # to connect to the server.
+  #tls:
+    # These are paths to certificate and key files. The files must be
+    # PEM-encoded X509 files. Both of these properties must be
+    # specified.
+    #cert: /path/to/cert
+    #key: /path/to/private-key
+
+    # This minimum version of TLS to accept. Defaults to 1.0. Other
+    # allowed values are 1.1, 1.2, and 1.3.
+    #min_version: 1.0
+
+    # The ciphers to allow or disallow for TLS 1.2 and below. *
+    # Below are the supported cipher suites and which ones are allowed
+    # by default.
+    #
+    #   Allowed     TLS_RSA_WITH_AES_128_CBC_SHA
+    #   Allowed     TLS_RSA_WITH_AES_256_CBC_SHA
+    #   Allowed     TLS_RSA_WITH_AES_128_GCM_SHA256                (TLS 1.2 only)
+    #   Allowed     TLS_RSA_WITH_AES_256_GCM_SHA384                (TLS 1.2 only)
+    #   Allowed     TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+    #   Allowed     TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+    #   Allowed     TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+    #   Allowed     TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+    #   Allowed     TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256        (TLS 1.2 only)
+    #   Allowed     TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384        (TLS 1.2 only)
+    #   Allowed     TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256          (TLS 1.2 only)
+    #   Allowed     TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384          (TLS 1.2 only)
+    #   Allowed     TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256    (TLS 1.2 only)
+    #   Allowed     TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256  (TLS 1.2 only)
+    #   Disallowed  TLS_RSA_WITH_RC4_128_SHA
+    #   Disallowed  TLS_RSA_WITH_3DES_EDE_CBC_SHA
+    #   Disallowed  TLS_RSA_WITH_AES_128_CBC_SHA256                (TLS 1.2 only)
+    #   Disallowed  TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+    #   Disallowed  TLS_ECDHE_RSA_WITH_RC4_128_SHA
+    #   Disallowed  TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+    #   Disallowed  TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256        (TLS 1.2 only)
+    #   Disallowed  TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256          (TLS 1.2 only)
+    #
+    # * For TLS 1.3, supported cipher suites are the following and are not configurable:
+    #     TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256
+    #
+    #ciphers:
+      # Only one of the following may be present. If 'allow' is present,
+      # it enumerates ALL allowed cipher suites. Any cipher not named is
+      # not allowed.
+      #allow: []
+      # If 'disallow' is present, it enumerates ALL disallowed cipher
+      # suites. Any cipher not named but present in the table above is
+      # allowed.
+      #disallow: []
+
+    # If the 'client_certs' section is present, TLS certificates will
+    # be requested from clients during the handshake.
+    #client_certs:
+      # If false or absent, client certs are verified if given, but are
+      # not required. If true, connections will be terminated if the
+      # client does not provide a valid cert.
+      #
+      # When a client cert is present and valid, the authenticated
+      # identity ("subject" field of the cert) will be added to HTTP
+      # headers for all requests to backends.
+      #require: true
+
+      # This is the path to PEM-encoded X509 certificate pool file that
+      # contains certs for CAs (certificate authorities/issuers). These
+      # are used to verify client certs.
+      #cacert: /path/to/ca-cert
 
 backends:
 # You can define any number of backends. For this example, there is
@@ -33,6 +106,47 @@ backends:
 # github.com/bufbuild/knit-demo repo:
 - route_to: http://127.0.0.1:30485
   # 30485 is the default port used by swapi-server.
+
+  # If specified, the gateway will use the named unix domain socket
+  # to connect to the backend.
+  #unix_socket: /path/to/domain/socket
+
+  # A 'tls' section may be present (but is not required) for
+  # backends that use "https". Any property that is NOT present
+  # will use the value present in the 'default_tls' top-level
+  # config stanza, if present. If that top-level stanza is not
+  # present, then the defaults described below apply.
+  #tls:
+    # This minimum version of TLS to accept. Defaults to 1.2. Other
+    # allowed values are 1.1, 1.2, and 1.3.
+    # NOTE: this is a different default than for the listener config.
+    # This listener default is more lenient, to support external
+    # clients that use older browser or mobile OS software.
+    #min_version: 1.2
+
+    # The ciphers to allow or disallow for TLS 1.2 and below. See the
+    # info above (under 'listener.tls' config) for more details on
+    # configuring cipher suites.
+    #ciphers:
+      #allow: []
+      #disallow: []
+
+    # This is the path to PEM-encoded X509 certificate pool file that
+    # contains certs for CAs (certificate authorities/issuers). These
+    # are used to verify server certs of the backend.
+    #cacert: /path/to/ca-cert
+    # This flag DISABLES verification of server certs. Its use is
+    # strongly discouraged. It is present primarily to aid with
+    # testing.
+    #skip_verify: false
+
+    # These are paths to certificate and key files to use as a client
+    # cert, when connecting to the backend. The files must be
+    # PEM-encoded X509 files. Both must be present together, to enable
+    # client certs, or both must be absent, to connect to the backend
+    # without a client cert.
+    #cert: /path/to/cert
+    #key: /path/to/private-key
 
   # By default, the gateway will use the Connect protocol to send
   # RPCs to the backend. It can be configured to use gRPC or
@@ -51,7 +165,7 @@ backends:
     - buf.knit.demo.swapi.species.v1.SpeciesService
     - buf.knit.demo.swapi.starship.v1.StarshipService
     - buf.knit.demo.swapi.vehicle.v1.VehicleService
-    # relations
+    # These services define relation resolvers:
     - buf.knit.demo.swapi.relations.v1.FilmResolverService
     - buf.knit.demo.swapi.relations.v1.PersonResolverService
     - buf.knit.demo.swapi.relations.v1.PlanetResolverService
@@ -92,7 +206,29 @@ backends:
   #
 
   # Since gRPC reflection uses a full-duplex bidi stream, we must
-  # use h2c to use it with a plain-text server. H2C simply means
-  # HTTP/2 over plain-text. (Note that not all HTTP servers support
-  # this! It usually requires special server configuration.)
+  # use HTTP/2. Usually, HTTP/2 is negotiated during the TLS
+  # handshake. But since we are using plaintext to talk to the
+  # server (i.e. the scheme in 'route_to' above is "http", not
+  # "https"), we must enable H2C. H2C simply means HTTP/2 over
+  # plain-text.
+  #
+  # NOTE: NOT all HTTP servers support this! It usually requires
+  # special server configuration. For this case, swapi-server DOES
+  # support it, so this setting will work.
   h2c: true
+
+# If many or all backends use the same TLS configuration, then
+# specify it here instead of repeating it in the 'tls' stanza for
+# each backend.
+#default_tls:
+  # This section supports all of the same properties as the 'tls'
+  # section under 'backends' above, EXCEPT for 'server_name'. That
+  # property must be provided on a per-backend basis.
+  #min_version: 1.2
+  #ciphers:
+    #allow: []
+    #disallow: []
+  #cacert: /path/to/ca-cert
+  #skip_verify: false
+  #cert: /path/to/cert
+  #key: /path/to/private-key


### PR DESCRIPTION
Also added support for unix sockets, since it was a fairly small change considering all of the other stuff in here.

I did exploratory testing to test all manner of configuration:
1. `knitgateway` using TLS, with and without requiring client certs, with and without unix socket
2. `knitgateway` using unix socket on plain text, both with and without H2C
3. backend server using TLS, with and without requiring client certs, with and without unix socket
   * `knitgateway` with proper cacert config and with 'skip_verify' insecure setting
4. backend server using unix socket on plain text

I used a test program I wrote way back when, for testing TLS and unix socket parameters of `grpcurl`, as the backend for bullets 3 and 4 above: https://github.com/fullstorydev/grpcurl/tree/master/internal/testing/cmd/testserver

I used `buf curl` as the frontend, since it also has parameters for TLS and unix sockets.

I found a few issues and fixed them in the third commit. One was actually a latent bug that had nothing to do with TLS: if a server replied with a zero-length response message, the gateway would panic trying to unmarshal it.

Fixes TCN-1536.