### PR TITLE
Need to block a few more headers

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -32,16 +32,19 @@ import (
 //
 //nolint:gochecknoglobals
 var forbiddenHeaders = map[string]struct{}{
-	"connect":           {},
 	"accept":            {},
+	"connect":           {},
 	"connection":        {},
 	"expect":            {},
 	"host":              {},
+	"http2-settings":    {},
 	"keep-alive":        {},
 	"origin":            {},
+	"proxy-connection":  {},
 	"te":                {},
 	"trailer":           {},
 	"transfer-encoding": {},
+	"upgrade":           {},
 }
 
 type handler struct {
@@ -272,6 +275,7 @@ func propagateHeaders(src http.Header, dest http.Header) {
 			strings.HasPrefix(lowerName, "accept-"),
 			strings.HasPrefix(lowerName, "connect-"),
 			strings.HasPrefix(lowerName, "content-"),
+			strings.HasPrefix(lowerName, "grpc-"),
 			strings.HasPrefix(lowerName, "if-"):
 			// skip these, too
 			continue

--- a/handler.go
+++ b/handler.go
@@ -33,6 +33,8 @@ import (
 //nolint:gochecknoglobals
 var forbiddenHeaders = map[string]struct{}{
 	"connect":           {},
+	"accept":            {},
+	"connection":        {},
 	"expect":            {},
 	"host":              {},
 	"keep-alive":        {},


### PR DESCRIPTION
We try to block protocol/transport-specific headers for incoming requests from the set of headers that we propagate to backends. It turns out that this list was incomplete.

In particular, we would propagate a "Connection: keep-alive" header which (at least with a Go backend using H2C) causes the connection to behave incorrectly and the RPC to timeout. That was the culprit in the bug that we observed.

I also noticed the "Accept" header was being propagated (since we were only blocking headers that start with "Accept-"). In addition to blocking "Connection", I also added other headers to the block list -- ones that the [RFC on HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2) says should not be propagated (we already blocked most of them, but "Connection", "Proxy-Connection", and "Upgrade" weren't in our list). And I also added "Http2-Settings" to the block list as well as gRPC-protocol-specific headers (we already blocked Connect-protocol-specific headers, so this is just fleshing it out further).

Fixes TCN-1704