### PR TITLE
Add version flag to knitgateway

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X main.buildVersion=v{{.Version}}
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ COPYRIGHT_YEARS := 2023
 LICENSE_IGNORE := -e testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
+DEV_BUILD_VERSION=$(shell git describe --always --dirty)
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -62,7 +63,7 @@ lintfix: $(BIN)/golangci-lint ## Automatically fix some lint errors
 
 .PHONY: install
 install: ## Install all binaries
-	$(GO) install ./...
+	$(GO) install -ldflags '-X "main.buildVersionSuffix=-$(DEV_BUILD_VERSION)"' ./...
 
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies

--- a/cmd/knitgateway/main.go
+++ b/cmd/knitgateway/main.go
@@ -40,13 +40,27 @@ const (
 	logFormatJSON    = "json"
 )
 
+//nolint:gochecknoglobals
+var (
+	// TODO: Change this after v0.1.0 is released.
+	// (var instead of const so it could be changed via -X ldflags).
+	buildVersion       = "v0.1.0-dev"
+	buildVersionSuffix = ""
+)
+
 func main() {
 	flagSet := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	conf := flagSet.String("conf", "knitgateway.yaml", "The path to a YAML config file.")
 	logFormat := flagSet.String("log-format", logFormatConsole, fmt.Sprintf("Can be %q or %q.", logFormatConsole, logFormatJSON))
 	help := flagSet.Bool("help", false, "Show usage information.")
+	version := flagSet.Bool("version", false, "Show the version and exit.")
 	flagSet.Usage = func() { printUsage(flagSet) }
 	_ = flagSet.Parse(os.Args[1:])
+
+	if *version {
+		fmt.Println(buildVersion + buildVersionSuffix)
+		return
+	}
 
 	if flag.NArg() > 0 {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\nThis command does not accept any positional arguments.\n", flag.Arg(0))


### PR DESCRIPTION
This adds a version flag to `knitgateway` and configures it to return `v0.1.0-dev`.

If you build via `make install`, you'll get a little more info, for example `v0.1.0-dev-dc338f9-dirty` (if build from a dirty working tree) or `v0.1.0-dev-58fb5c6` (if not).

This adds `goreleaser` config so that it will set the version based on the release tag. That isn't strictly necessary since, if we follow `bufbuild/buf`'s release approach, we'll have to first make a PR that sets the version (for example to `v0.1.0`), then drop the tag and release, and finally update the version again (e.g. `v0.2.0-dev`). I don't _love_ that approach since it requires two PRs per release (if we _only_ set the version via `-ldflags "-X ..."` we could do it with zero -- just `git tag v0.1.0 && make release`). The main upside, however, is that anyone who builds the binary using the release tag always sees the correct version reported. I guess we can cross that bridge when we get there 🤷.

Fixes TCN-1734