### PR TITLE
Remove some signals to make Windows build happy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,3 +41,8 @@ jobs:
         # supported version.
         if: matrix.go-version == '1.20.x'
         run: make checkgenerate && make lint
+      - name: Check Release
+        # We'll only be building releases w/ latest Go, so we only need to
+        # test that it can be built w/ latest.
+        if: matrix.go-version == '1.20.x'
+        run: make checkrelease

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,13 @@ release:
 	go install github.com/goreleaser/goreleaser@v1.16.2
 	goreleaser release
 
+.PHONY: checkrelease
+checkrelease:
+	go install github.com/goreleaser/goreleaser@v1.16.2
+	# skips some validation and doesn't actually publish a release, just to test
+	# that building a release works
+	goreleaser release --clean --snapshot
+
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \

--- a/cmd/knitgateway/main.go
+++ b/cmd/knitgateway/main.go
@@ -133,7 +133,7 @@ func main() {
 	ignored := make(chan os.Signal, 1)
 	signal.Notify(ignored, syscall.SIGHUP)
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT, syscall.SIGALRM, syscall.SIGQUIT, syscall.SIGTSTP, syscall.SIGUSR1, syscall.SIGUSR2)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT, syscall.SIGALRM, syscall.SIGQUIT)
 
 	group, grpCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {


### PR DESCRIPTION
Before we can land #17, we need the release to actually build. The release includes a cross-compile for Windows, which was failing to build because the compiler couldn't resolve the `syscall.SIGTSTP`, `syscall.SIGUSR1`, and `syscall.SIGUSR2` references.

Instead of adding build tags to only include these signals for non-Windows, it was simpe enough to just leave them out. It's probably okay on Unix if these signals incur the default handler (which would mean unclean termination).

I also added a new make target so that we can verify the release will build as part of CI.
