### PR TITLE
Improve naming of release artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,7 @@ archives:
         format: zip
     rlcp: true
     # Follows same naming conventions as release artifacts for bufbuild/buf
-    name_template: '{{ .ProjectName }}-{{ .Tag }}-{{ title .Os }}-{{ if and (eq .Os "linux") (eq .Arch "arm64")}}aarch64{{ else if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}'
+    name_template: 'knitgateway-{{ .Tag }}-{{ title .Os }}-{{ if and (eq .Os "linux") (eq .Arch "arm64")}}aarch64{{ else if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}'
     files:
       - LICENSE
       - knitgateway.example.yaml


### PR DESCRIPTION
In the current releases (v0.0.1 and v0.0.2), the release artifacts are named like `knit-go-...`. Back when this project also included a proto plugin, perhaps that would make sense. (Though it would likely make more sense to upload separate artifacts for the multiple binaries instead of a single artifact with them all?)

Anyhow, now, since the artifact is just for the standalone gateway, it should be named `knitgateway-...`.