### PR TITLE
Drop actions cache for setup-go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,12 +26,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - uses: bufbuild/buf-setup-action@v1.26.0
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-knit-go-ci-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-knit-go-ci-
       - name: Test
         run: make test
       - name: Lint


### PR DESCRIPTION
Setup v4 now caches by default.