### PR TITLE
The knitgateway presents a custom user-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ lintfix: $(BIN)/golangci-lint ## Automatically fix some lint errors
 
 .PHONY: install
 install: ## Install all binaries
-	$(GO) install -ldflags '-X "main.buildVersionSuffix=-$(DEV_BUILD_VERSION)"' ./...
+	$(GO) install -ldflags '-X "github.com/bufbuild/knit-go/internal/app/knitgateway.buildVersionSuffix=-$(DEV_BUILD_VERSION)"' ./...
 
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies

--- a/cmd/knitgateway/main.go
+++ b/cmd/knitgateway/main.go
@@ -41,13 +41,6 @@ const (
 	logFormatJSON    = "json"
 )
 
-//nolint:gochecknoglobals
-var (
-	// (var instead of const so it could be changed via -X ldflags).
-	buildVersion       = "v0.1.0-dev"
-	buildVersionSuffix = ""
-)
-
 //nolint:gocyclo
 func main() {
 	flagSet := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -59,7 +52,7 @@ func main() {
 	_ = flagSet.Parse(os.Args[1:])
 
 	if *version {
-		fmt.Println(buildVersion + buildVersionSuffix)
+		fmt.Println(knitgateway.Version())
 		return
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -45,6 +45,11 @@ var forbiddenHeaders = map[string]struct{}{
 	"trailer":           {},
 	"transfer-encoding": {},
 	"upgrade":           {},
+	// User-Agent is not forbidden, but we intentionally do NOT forward
+	// it since the outbound requests are sufficiently distinct from
+	// the original request. Instead, the gateway presents itself as
+	// the user agent to RPC backends.
+	"user-agent": {},
 }
 
 type handler struct {

--- a/internal/app/knitgateway/config.go
+++ b/internal/app/knitgateway/config.go
@@ -158,7 +158,9 @@ func LoadConfig(path string) (*GatewayConfig, error) { //nolint:gocyclo
 			return nil, fmt.Errorf("backend config #%d: %q is not a valid URL: schema should be '%s' or '%s'",
 				i+1, backendConf.RouteTo, httpScheme, httpsScheme)
 		}
-		var options []connect.ClientOption
+		options := []connect.ClientOption{
+			connect.WithInterceptors(connect.UnaryInterceptorFunc(UserAgentInterceptor)),
+		}
 		switch backendConf.Encoding {
 		case "", protoEncoding:
 			// nothing to do; this is the default

--- a/internal/app/knitgateway/descriptors.go
+++ b/internal/app/knitgateway/descriptors.go
@@ -117,7 +117,10 @@ func (b bufModuleSource) newPoller(_ connect.HTTPClient, _ []connect.ClientOptio
 	reflectClient := reflectv1beta1connect.NewFileDescriptorSetServiceClient(
 		http.DefaultClient,
 		"https://api."+remote,
-		connect.WithInterceptors(prototransform.NewAuthInterceptor(token)),
+		connect.WithInterceptors(
+			prototransform.NewAuthInterceptor(token),
+			connect.UnaryInterceptorFunc(UserAgentInterceptor),
+		),
 	)
 	return prototransform.NewSchemaPoller(reflectClient, module, version), nil
 }

--- a/internal/app/knitgateway/version.go
+++ b/internal/app/knitgateway/version.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package knitgateway
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+)
+
+const buildVersion = "v0.1.0-dev"
+
+//nolint:gochecknoglobals
+var (
+	// NB: This is a var instead of a const so it can be changed via -X ldflags.
+	buildVersionSuffix = ""
+)
+
+func Version() string {
+	return buildVersion + buildVersionSuffix
+}
+
+func UserAgentInterceptor(call connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		// decorate user-agent with the program name and version
+		userAgent := fmt.Sprintf("knitgateway/%s %s", Version(), req.Header().Get("User-Agent"))
+		req.Header().Set("User-Agent", userAgent)
+		return call(ctx, req)
+	}
+}

--- a/internal/app/knitgateway/version.go
+++ b/internal/app/knitgateway/version.go
@@ -36,7 +36,7 @@ func Version() string {
 func UserAgentInterceptor(call connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		// decorate user-agent with the program name and version
-		userAgent := fmt.Sprintf("knitgateway/%s %s", Version(), req.Header().Get("User-Agent"))
+		userAgent := fmt.Sprintf("%s knitgateway/%s", req.Header().Get("User-Agent"), Version())
 		req.Header().Set("User-Agent", userAgent)
 		return call(ctx, req)
 	}


### PR DESCRIPTION
This adds the name and version of the gateway to the user-agent for all outbound RPCs, to both RPC backends but also to a BSR for fetching schemas.

This also causes all gateways (even custom ones that use this package as a library, instead of using the standalone gateway binary) to present _themselves_ as the clients to RPC backends via the user-agent header via the user-agent field, instead of propagating the user-agent from the client's request. This will be the default user-agent from the connect-go library if the program does not otherwise customize it.