### PR TITLE
Prepare for v0.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,14 @@ COPYRIGHT_YEARS := 2023
 LICENSE_IGNORE := -e testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
-DEV_BUILD_VERSION=$(shell git describe --always --dirty)
+LATEST_VERSION = $(shell git describe --tags --abbrev=0)
+CURRENT_VERSION = $(shell git describe --tags --always --dirty)
+# If not on release tag, this is a dev build. Add suffix to version.
+ifneq ($(CURRENT_VERSION), $(LATEST_VERSION))
+	DEV_BUILD_VERSION_DIRECTIVE = buildVersionSuffix=-$(shell git describe --exclude '*' --always --dirty)
+else
+	DEV_BUILD_VERSION_DIRECTIVE = buildVersion=$(CURRENT_VERSION)
+endif
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -63,7 +70,7 @@ lintfix: $(BIN)/golangci-lint ## Automatically fix some lint errors
 
 .PHONY: install
 install: ## Install all binaries
-	$(GO) install -ldflags '-X "github.com/bufbuild/knit-go/internal/app/knitgateway.buildVersionSuffix=-$(DEV_BUILD_VERSION)"' ./...
+	$(GO) install -ldflags '-X "github.com/bufbuild/knit-go/internal/app/knitgateway.$(DEV_BUILD_VERSION_DIRECTIVE)"' ./...
 
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies

--- a/cmd/knitgateway/main.go
+++ b/cmd/knitgateway/main.go
@@ -52,7 +52,7 @@ func main() {
 	_ = flagSet.Parse(os.Args[1:])
 
 	if *version {
-		fmt.Println(knitgateway.Version())
+		fmt.Println(knitgateway.Version)
 		return
 	}
 

--- a/internal/app/knitgateway/version.go
+++ b/internal/app/knitgateway/version.go
@@ -21,22 +21,20 @@ import (
 	"connectrpc.com/connect"
 )
 
-const buildVersion = "v0.1.0-dev"
-
 //nolint:gochecknoglobals
 var (
-	// NB: This is a var instead of a const so it can be changed via -X ldflags.
+	// NB: These are vars instead of consts so they can be changed via -X ldflags.
+	buildVersion       = "v0.1.0"
 	buildVersionSuffix = ""
-)
 
-func Version() string {
-	return buildVersion + buildVersionSuffix
-}
+	// Version is the gateway version to report.
+	Version = buildVersion + buildVersionSuffix
+)
 
 func UserAgentInterceptor(call connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		// decorate user-agent with the program name and version
-		userAgent := fmt.Sprintf("%s knitgateway/%s", req.Header().Get("User-Agent"), Version())
+		userAgent := fmt.Sprintf("%s knitgateway/%s", req.Header().Get("User-Agent"), Version)
 		req.Header().Set("User-Agent", userAgent)
 		return call(ctx, req)
 	}


### PR DESCRIPTION
This also fixes the `Makefile` rules so that `make install` always builds binary with correct version, only adding a suffix when building non-release commit.