### PR TITLE
Fix goreleaser config for setting version number

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.buildVersion=v{{.Version}}
+      - -s -w -X github.com/bufbuild/knit-go/internal/app/knitgateway.buildVersion=v{{.Version}}
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
This isn't a real issue in practice since the default value of the var should be correct. This configuration for `goreleaser` is only in place in the off-chance that we tag a sha where the var has not been correctly updated. In that case, both `make install` and `goreleaser` will update the var so the built binary emits the correct version.

This was using the wrong package because I forgot to update this config in #37, when this var was moved out of the main package into an internal app package.