### PR TITLE
Upgrade go version to 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: bufbuild/buf-setup-action@v1.28.1
+      - uses: bufbuild/buf-setup-action@v1.29.0-1
       - name: Test
         run: make test
       - name: Lint
@@ -33,10 +33,10 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.21.x'
+        if: matrix.go-version == '1.22.x'
         run: make checkgenerate && make lint
       - name: Check Release
         # We'll only be building releases w/ latest Go, so we only need to
         # test that it can be built w/ latest.
-        if: matrix.go-version == '1.21.x'
+        if: matrix.go-version == '1.22.x'
         run: make checkrelease

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/knit-go
 
-go 1.19
+go 1.20
 
 require (
 	buf.build/gen/go/bufbuild/knit/connectrpc/go v1.14.0-20230822193418-257a6c375e3f.1


### PR DESCRIPTION
Bumps the minimum go version to 1.20 and the latest at 1.22. Also increases the buf-setup-actions to latest 1.29.0-1.