### PR TITLE
Update to go 1.21 and golangci-lint 1.60.0; test with go 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,10 +33,10 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint
       - name: Check Release
         # We'll only be building releases w/ latest Go, so we only need to
         # test that it can be built w/ latest.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkrelease

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -34,31 +32,27 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - depguard          # draconian in unhelpful ways
+    - err113            # don't _always_ need to wrap errors
+    - execinquery       # deprecated in golangci 1.58.0
     - exhaustruct       # not useful for this repo (we want to rely on zero values for fields)
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
+    - mnd               # some unnamed constants are okay
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine, it's *bare* returns that are not
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
+    - protogetter       # too many false positives
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.

--- a/Makefile
+++ b/Makefile
@@ -101,4 +101,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0

--- a/format_test.go
+++ b/format_test.go
@@ -16,7 +16,7 @@ package knit
 
 import (
 	"encoding/base64"
-	"fmt"
+	"errors"
 	"math"
 	"os"
 	"testing"
@@ -201,7 +201,7 @@ func TestFormatMessage(t *testing.T) {
 
 func TestFormatError(t *testing.T) {
 	t.Parallel()
-	relErr := connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("msg"))
+	relErr := connect.NewError(connect.CodeInvalidArgument, errors.New("msg"))
 	foo := &knittest.Foo{
 		Name: "name",
 	}
@@ -211,7 +211,7 @@ func TestFormatError(t *testing.T) {
 	val := formatError(relErr, "foo", protoregistry.GlobalTypes)
 	fooBytes, err := proto.Marshal(foo)
 	require.NoError(t, err)
-	require.Equal(t, val.AsInterface(), map[string]any{
+	require.Equal(t, map[string]any{
 		"[@error]": map[string]any{},
 		"code":     gatewayv1alpha1.Error_INVALID_ARGUMENT.String(),
 		"message":  "msg",
@@ -225,7 +225,7 @@ func TestFormatError(t *testing.T) {
 				},
 			},
 		},
-	})
+	}, val.AsInterface())
 }
 
 type patchExpectation struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/knit-go
 
-go 1.20
+go 1.21
 
 require (
 	buf.build/gen/go/bufbuild/knit/connectrpc/go v1.14.0-20230822193418-257a6c375e3f.1

--- a/internal/app/knitgateway/admin.go
+++ b/internal/app/knitgateway/admin.go
@@ -29,7 +29,7 @@ import (
 // RegisterAdminHandlers registers "/admin/" HTTP handlers on the given mux, to
 // expose admin functions for the given gateway.
 func RegisterAdminHandlers(gateway *Gateway, mux *http.ServeMux) {
-	handleFunc(mux, "/admin/", http.MethodGet, func(respWriter http.ResponseWriter, req *http.Request) {
+	handleFunc(mux, "/admin/", http.MethodGet, func(respWriter http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(respWriter, `
 		<html>
 		<head><title>Admin :: knitgateway</title></head>
@@ -44,11 +44,11 @@ func RegisterAdminHandlers(gateway *Gateway, mux *http.ServeMux) {
 		</body>
 		`)
 	})
-	handleFunc(mux, "/admin/config", http.MethodGet, func(respWriter http.ResponseWriter, req *http.Request) {
+	handleFunc(mux, "/admin/config", http.MethodGet, func(respWriter http.ResponseWriter, _ *http.Request) {
 		respWriter.Header().Set("Content-Type", "text/yaml")
 		_, _ = respWriter.Write(gateway.config.RawConfig)
 	})
-	handleFunc(mux, "/admin/reload-now", http.MethodPost, func(respWriter http.ResponseWriter, req *http.Request) {
+	handleFunc(mux, "/admin/reload-now", http.MethodPost, func(respWriter http.ResponseWriter, _ *http.Request) {
 		for _, watcher := range gateway.watchers {
 			watcher.ResolveNow()
 		}

--- a/internal/app/knitgateway/cache.go
+++ b/internal/app/knitgateway/cache.go
@@ -16,6 +16,7 @@ package knitgateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -123,7 +124,7 @@ func (c *externalRedisCacheConfig) toCache() (prototransform.Cache, io.Closer, e
 	if c.RequireAuth {
 		password = os.Getenv("REDIS_PASSWORD")
 		if password == "" {
-			return nil, nil, fmt.Errorf("redis.require_auth is true but no REDIS_PASSWORD in environment")
+			return nil, nil, errors.New("redis.require_auth is true but no REDIS_PASSWORD in environment")
 		}
 		// user is optional
 		user = os.Getenv("REDIS_USER")

--- a/internal/app/knitgateway/config.go
+++ b/internal/app/knitgateway/config.go
@@ -117,7 +117,7 @@ func LoadConfig(path string) (*GatewayConfig, error) { //nolint:gocyclo
 	}
 
 	if len(extConf.Backends) == 0 {
-		return nil, fmt.Errorf("backends config is empty")
+		return nil, errors.New("backends config is empty")
 	}
 
 	adminConf, err := loadAdminConfig(&extConf)
@@ -140,7 +140,7 @@ func LoadConfig(path string) (*GatewayConfig, error) { //nolint:gocyclo
 		return nil, fmt.Errorf("default_tls: invalid configuration: %w", err)
 	}
 	if extConf.DefaultBackendTLS != nil && extConf.DefaultBackendTLS.ServerName != "" {
-		return nil, fmt.Errorf("default_tls: invalid configuration: server_name property cannot be used in default settings, only in per-backend config")
+		return nil, errors.New("default_tls: invalid configuration: server_name property cannot be used in default settings, only in per-backend config")
 	}
 
 	for i, backendConf := range extConf.Backends {
@@ -468,7 +468,7 @@ func loadAdminConfig(extConf *externalGatewayConfig) (*AdminConfig, error) {
 	if !adminEnabled {
 		if extConf.Admin.UseMainListeners || extConf.Admin.BindAddress != "" ||
 			extConf.Admin.Port != 0 || extConf.Admin.UseTLS != nil {
-			return nil, fmt.Errorf("admin 'enabled' is false, but other properties for configuring admin endpoints also present")
+			return nil, errors.New("admin 'enabled' is false, but other properties for configuring admin endpoints also present")
 		}
 		return nil, nil //nolint:nilnil
 	}
@@ -477,16 +477,16 @@ func loadAdminConfig(extConf *externalGatewayConfig) (*AdminConfig, error) {
 	if extConf.Admin.UseMainListeners {
 		adminConf.UseMainListeners = true
 		if extConf.Admin.BindAddress != "" || extConf.Admin.Port != 0 || extConf.Admin.UseTLS != nil {
-			return nil, fmt.Errorf("admin 'use_main_listeners' is true, but other properties for configuring separate listener are also present")
+			return nil, errors.New("admin 'use_main_listeners' is true, but other properties for configuring separate listener are also present")
 		}
 		return &adminConf, nil
 	}
 
 	if extConf.Admin.UseTLS != nil && *extConf.Admin.UseTLS && extConf.Listen.TLS == nil {
-		return nil, fmt.Errorf("admin config 'use_tls' is true, but no server TLS configuration present")
+		return nil, errors.New("admin config 'use_tls' is true, but no server TLS configuration present")
 	}
 	if extConf.Listen.Port != nil && extConf.Admin.Port == *extConf.Listen.Port {
-		return nil, fmt.Errorf("admin port cannot be the same as main listen port (did you mean to instead set 'use_main_listeners' to true?)")
+		return nil, errors.New("admin port cannot be the same as main listen port (did you mean to instead set 'use_main_listeners' to true?)")
 	}
 	if extConf.Admin.UseTLS != nil {
 		adminConf.UseTLS = *extConf.Admin.UseTLS

--- a/internal/app/knitgateway/descriptors.go
+++ b/internal/app/knitgateway/descriptors.go
@@ -16,6 +16,7 @@ package knitgateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -61,12 +62,12 @@ func newDescriptorSource(config externalDescriptorConfig, targetURL string, h2c 
 
 	case config.GRPCReflection:
 		if !strings.HasPrefix(targetURL, httpsScheme) && !h2c {
-			return zero, fmt.Errorf("cannot use grpc reflection with http scheme without H2C")
+			return zero, errors.New("cannot use grpc reflection with http scheme without H2C")
 		}
 		return grpcReflectionSource(targetURL), nil
 
 	default:
-		return zero, fmt.Errorf("descriptor config is empty")
+		return zero, errors.New("descriptor config is empty")
 	}
 }
 
@@ -94,7 +95,7 @@ func (f descriptorSetFileSource) newPoller(_ connect.HTTPClient, _ []connect.Cli
 type bufModuleSource string
 
 func (b bufModuleSource) String() string {
-	return fmt.Sprintf("module %s", string(b))
+	return "module " + string(b)
 }
 
 func (b bufModuleSource) isCacheable() bool {
@@ -128,7 +129,7 @@ func (b bufModuleSource) newPoller(_ connect.HTTPClient, _ []connect.ClientOptio
 type grpcReflectionSource string
 
 func (g grpcReflectionSource) String() string {
-	return fmt.Sprintf("gRPC server reflection %s", string(g))
+	return "gRPC server reflection " + string(g)
 }
 
 func (g grpcReflectionSource) isCacheable() bool {
@@ -236,7 +237,7 @@ func (g *grpcReflectionPoller) GetSchema(ctx context.Context, symbols []string, 
 }
 
 func (g *grpcReflectionPoller) GetSchemaID() string {
-	return fmt.Sprintf("grpc reflection %s", g.baseURL)
+	return "grpc reflection " + g.baseURL
 }
 
 func descriptorKind(desc protoreflect.Descriptor) string {

--- a/internal/app/knitgateway/tls.go
+++ b/internal/app/knitgateway/tls.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -101,7 +102,7 @@ func configureServerTLS(conf *externalServerTLSConfig) (*tls.Config, error) {
 	}
 	var tlsConf tls.Config
 	if conf.Cert == "" || conf.Key == "" {
-		return nil, fmt.Errorf("both 'cert' and 'key' properties must be specified")
+		return nil, errors.New("both 'cert' and 'key' properties must be specified")
 	}
 	certs, err := loadCertificateAndKey(conf.Cert, conf.Key)
 	if err != nil {
@@ -137,7 +138,7 @@ func configureServerTLS(conf *externalServerTLSConfig) (*tls.Config, error) {
 			tlsConf.ClientAuth = tls.VerifyClientCertIfGiven
 		}
 		if conf.ClientCerts.CACert == "" {
-			return nil, fmt.Errorf("'client_certs' config is enabled but 'ca_cert' property is missing")
+			return nil, errors.New("'client_certs' config is enabled but 'ca_cert' property is missing")
 		}
 		var err error
 		tlsConf.ClientCAs, err = loadCertificatePool(conf.ClientCerts.CACert)
@@ -158,7 +159,7 @@ func configureClientTLS(conf *externalClientTLSConfig) (*tls.Config, error) {
 	}
 
 	if (conf.Cert == nil) != (conf.Key == nil) {
-		return nil, fmt.Errorf("if either 'cert' and 'key' is specified then both must be specified")
+		return nil, errors.New("if either 'cert' and 'key' is specified then both must be specified")
 	}
 	if conf.Cert != nil {
 		certs, err := loadCertificateAndKey(*conf.Cert, *conf.Key)
@@ -254,7 +255,7 @@ func parseTLSVersion(version string) (uint16, error) {
 func parseCipherSuites(conf *externalCiphersConfig) ([]uint16, error) {
 	switch {
 	case conf.Allow != nil && conf.Disallow != nil:
-		return nil, fmt.Errorf("ciphers config must specify either allow or disallow, but not both")
+		return nil, errors.New("ciphers config must specify either allow or disallow, but not both")
 	case conf.Allow != nil:
 		ciphers := make([]uint16, len(conf.Allow))
 		for i, cipher := range conf.Allow {
@@ -289,16 +290,16 @@ func parseCipherSuites(conf *externalCiphersConfig) ([]uint16, error) {
 		})
 		return ciphers, nil
 	default:
-		return nil, fmt.Errorf("ciphers config must specify either allow or disallow; neither was present")
+		return nil, errors.New("ciphers config must specify either allow or disallow; neither was present")
 	}
 }
 
 func loadCertificateAndKey(cert, key string) ([]tls.Certificate, error) {
 	if cert == "" {
-		return nil, fmt.Errorf("cert filename is empty")
+		return nil, errors.New("cert filename is empty")
 	}
 	if key == "" {
-		return nil, fmt.Errorf("key filename is empty")
+		return nil, errors.New("key filename is empty")
 	}
 	certData, err := os.ReadFile(cert)
 	if err != nil {
@@ -321,7 +322,7 @@ func loadCertificateAndKey(cert, key string) ([]tls.Certificate, error) {
 
 func loadCertificatePool(cacert string) (*x509.CertPool, error) {
 	if cacert == "" {
-		return nil, fmt.Errorf("filename is empty")
+		return nil, errors.New("filename is empty")
 	}
 	data, err := os.ReadFile(cacert)
 	if err != nil {

--- a/internal/crosstest/cmd/crosstest-server/main.go
+++ b/internal/crosstest/cmd/crosstest-server/main.go
@@ -55,7 +55,7 @@ func main() {
 		log.Fatalln("failed to add relations service to gateway")
 	}
 	mux.Handle(knitGateway.AsHandler())
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	//nolint:gosec

--- a/internal/crosstest/services.go
+++ b/internal/crosstest/services.go
@@ -43,7 +43,7 @@ func NewParentService() *ParentService {
 
 func (s *ParentService) ListParents(context.Context, *connect.Request[crosstest.ListParentsRequest]) (*connect.Response[crosstest.ListParentsResponse], error) {
 	var parents []*crosstest.Parent
-	s.store.Range(func(key, value any) bool {
+	s.store.Range(func(_, value any) bool {
 		parents = append(parents, value.(*crosstest.Parent))
 		return true
 	})
@@ -100,7 +100,7 @@ func NewChildService(parentClient crosstestconnect.ParentServiceClient) *ChildSe
 
 func (s *ChildService) ListChildren(_ context.Context, req *connect.Request[crosstest.ListChildrenRequest]) (*connect.Response[crosstest.ListChildrenResponse], error) {
 	var children []*crosstest.Child
-	s.store.Range(func(key, value any) bool {
+	s.store.Range(func(_, value any) bool {
 		child := value.(*crosstest.Child) //nolint:errcheck
 		if strings.HasPrefix(child.Id, req.Msg.Parent) {
 			children = append(children, child)

--- a/knit_test.go
+++ b/knit_test.go
@@ -74,7 +74,7 @@ func TestEndToEnd(t *testing.T) {
 	go func() {
 		_ = svr.Serve(svrListen)
 	}()
-	target, err := url.Parse(fmt.Sprintf("http://" + svrListen.Addr().String()))
+	target, err := url.Parse("http://" + svrListen.Addr().String())
 	require.NoError(t, err)
 
 	// create and configure the knit gateway
@@ -119,7 +119,7 @@ func TestEndToEnd(t *testing.T) {
 	fooMask = fooMask[:i]
 
 	// now we can run the tests
-	knitClient := gatewayv1alpha1connect.NewKnitServiceClient(http.DefaultClient, fmt.Sprintf("http://"+gatewayListen.Addr().String()))
+	knitClient := gatewayv1alpha1connect.NewKnitServiceClient(http.DefaultClient, "http://"+gatewayListen.Addr().String())
 	ctx := context.Background()
 
 	addHeaders := func(headers http.Header) {
@@ -243,7 +243,7 @@ func TestEndToEnd(t *testing.T) {
 
 	t.Cleanup(func() {
 		var methods []string
-		methodsObserved.Range(func(k, v any) bool {
+		methodsObserved.Range(func(k, _ any) bool {
 			methods = append(methods, k.(string)) //nolint:forcetypeassert
 			return true
 		})
@@ -417,7 +417,7 @@ func (s *serverImpl) GetFooBars(_ context.Context, req *connect.Request[knittest
 }
 
 func (s *serverImpl) GetFooDescription(_ context.Context, _ *connect.Request[knittest.GetFooDescriptionRequest]) (*connect.Response[knittest.GetFooDescriptionResponse], error) {
-	return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("description not available"))
+	return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("description not available"))
 }
 
 func (s *serverImpl) GetBarBaz(_ context.Context, req *connect.Request[knittest.GetBarBazRequest]) (*connect.Response[knittest.GetBarBazResponse], error) {
@@ -528,12 +528,12 @@ func checkOperations(actualOps []string, procedure string) (errs []string) {
 			}
 			expectedOps = append(expectedOps, currentOp)
 		default:
-			errs = append(errs, fmt.Sprintf("unexpected relation: %s", currentOp))
+			errs = append(errs, "unexpected relation: "+currentOp)
 		}
 	}
 
 	if expectedOps == nil {
-		errs = append(errs, fmt.Sprintf("unexpected operation: %s", topLevelOp))
+		errs = append(errs, "unexpected operation: "+topLevelOp)
 	} else if !reflect.DeepEqual(expectedOps, actualOps) {
 		errs = append(errs, fmt.Sprintf("unexpected operations in resolver metadata: want %v; got %s", expectedOps, actualOps))
 	}

--- a/relation.go
+++ b/relation.go
@@ -16,6 +16,7 @@ package knit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -68,35 +69,35 @@ func getRelationConfig(method protoreflect.MethodDescriptor, name string, client
 	requestMsg := method.Input()
 	requestFields := requestMsg.Fields()
 	if requestFields.Len() < 1 {
-		return nil, fmt.Errorf("request message should have at least one field for the base entities")
+		return nil, errors.New("request message should have at least one field for the base entities")
 	}
 	baseField := requestFields.ByNumber(1)
 	switch {
 	case baseField == nil:
-		return nil, fmt.Errorf("request message should have a field with tag number 1 for the base entities")
+		return nil, errors.New("request message should have a field with tag number 1 for the base entities")
 	case baseField.Name() != "bases":
-		return nil, fmt.Errorf("request message should have a field named 'bases' for the base entities")
+		return nil, errors.New("request message should have a field named 'bases' for the base entities")
 	case !baseField.IsList():
-		return nil, fmt.Errorf("request message field named 'bases' should be repeated (to accept a batch of entities to resolve)")
+		return nil, errors.New("request message field named 'bases' should be repeated (to accept a batch of entities to resolve)")
 	case baseField.Kind() != protoreflect.MessageKind:
-		return nil, fmt.Errorf("request message field named 'bases' should have element type that is a message")
+		return nil, errors.New("request message field named 'bases' should have element type that is a message")
 	}
 
 	responseMsg := method.Output()
 	responseFields := responseMsg.Fields()
 	if responseFields.Len() != 1 {
-		return nil, fmt.Errorf("response message should have exactly one field for the resolved relation values")
+		return nil, errors.New("response message should have exactly one field for the resolved relation values")
 	}
 	resultField := responseFields.ByNumber(1)
 	switch {
 	case resultField == nil:
-		return nil, fmt.Errorf("response message should have a field with tag number 1 for the resolved relation values")
+		return nil, errors.New("response message should have a field with tag number 1 for the resolved relation values")
 	case resultField.Name() != "values":
-		return nil, fmt.Errorf("response message should have a field named 'values' for the resolved relation values")
+		return nil, errors.New("response message should have a field named 'values' for the resolved relation values")
 	case !resultField.IsList():
-		return nil, fmt.Errorf("response message field named 'values' should be repeated (one value for each requested base)")
+		return nil, errors.New("response message field named 'values' should be repeated (one value for each requested base)")
 	case resultField.Kind() != protoreflect.MessageKind:
-		return nil, fmt.Errorf("response message field named 'values' should have element type that is a single-field message")
+		return nil, errors.New("response message field named 'values' should have element type that is a single-field message")
 	}
 	relationWrapperMsg := resultField.Message()
 	relationWrapperFields := relationWrapperMsg.Fields()


### PR DESCRIPTION
A lot of code changes are to make the latest golangci-lint happy. Some of the new checks were noisy/useless, so I disabled them. But I decided to address the "perfsprint" linter issues and also, of course, fixed some issues newly identified by "govet".