### PR TITLE
Fix err113 config in golanglint-ci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # draconian in unhelpful ways
-    - err113            # don't _always_ need to wrap errors
     - execinquery       # deprecated in golangci 1.58.0
     - exhaustruct       # not useful for this repo (we want to rely on zero values for fields)
     - funlen            # rely on code review to limit function length
@@ -56,7 +55,7 @@ issues:
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"
   exclude-rules:
     - path: cmd/.*/main\.go
       linters:


### PR DESCRIPTION
Just realized that we already had config to ignore the noisy checks, so I needed to fix that instead of ignoring err113 entirely.